### PR TITLE
Change audio URL fragment

### DIFF
--- a/audio_manifest_builder.sh
+++ b/audio_manifest_builder.sh
@@ -75,7 +75,7 @@ fi
 echo "AUDIO_DIR:${AUDIO_DIR}" 
 
 #define variables 
-BASE_URL_HLS=http://${AUDIO_SERVER_NAME}/hls-vod/audio-only-aac/${APP_NAME_HLS}
+BASE_URL_HLS=http://${AUDIO_SERVER_NAME}/hls-vod/audio-only/${APP_NAME_HLS}
 
 #iterate over audio files in the directory
 for f in  ${AUDIO_DIR}/*_s.m4a


### PR DESCRIPTION
change audio-only-aac to audio-only in AMS URL to eliminate 404 error
e.g.,
-BASE_URL_HLS=http://${AUDIO_SERVER_NAME}/hls-vod/audio-only-aac/${APP_NAME_HLS}
+BASE_URL_HLS=http://${AUDIO_SERVER_NAME}/hls-vod/audio-only/${APP_NAME_HLS}